### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -255,6 +255,9 @@ function gc_theme_setup() {
 			return $html;
 	}
 	add_filter( 'widget_text','gc_execute_php_widgets' );
+	
+	// Allow shortcodes in excerpt
+	add_filter( 'the_excerpt', 'do_shortcode');
 
 } // <~Closing brace for genesis_setup function
 


### PR DESCRIPTION
I have one of those _**content upgrade/ opt-in/ get this post via email/ whatever the hell else it's called/**_ ....forms that allow the person to simply download the post (with an 'XYZ' bonus). 

So, I needed to add a shortcode that appears in excerpts **only**.  That way, when a viewer is on an /archive page, they see all the posts and all the optins, yet when they go to the actual post, it disappears _(b/c something else happens on the actual post page)_.  So, I added line 260 with a tid-bit of documentation.  

Merge it or leave it. Your choice. It is now just an option either way :+1: 
